### PR TITLE
Update kernel patch to apply again

### DIFF
--- a/meta-ar0521/recipes-kernel/linux/linux-toradex/0001-kernel-patches.patch
+++ b/meta-ar0521/recipes-kernel/linux/linux-toradex/0001-kernel-patches.patch
@@ -881,9 +881,9 @@ index 3c628fb1becd..6bc71b44c413 100644
  {
  	struct mxc_mipi_csi2_dev *csi2dev = sd_to_mxc_mipi_csi2_dev(sd);
 @@ -1182,6 +1269,15 @@ static struct v4l2_subdev_pad_ops mipi_csi2_pad_ops = {
- 
  static struct v4l2_subdev_core_ops mipi_csi2_core_ops = {
  	.s_power = mipi_csi2_s_power,
+ 	.ioctl = mipi_csi2_s_ioctl,
 +#ifdef CONFIG_VIDEO_ECAM
 +	.queryctrl = mipi_csi2_queryctrl,
 +	.g_ctrl = mipi_csi2_g_ctrl,


### PR DESCRIPTION
This adapts the patch to apply after linux-toradex commit 340bd44082a75 (media: i2c: ov5640: Add ov5640 test pattern in imx8 video stack).

This edits the patch by hand, so the line numbers are not refreshed, but with these changes the patch applies again. Tested with linux-toradex commit 6f32493eb88eb (PCI: imx6: Turn off regulator when system is in suspend mode).