### PR TITLE
update layer to be compatible with Scarthgap Yocto

### DIFF
--- a/meta-ar0521/conf/layer.conf
+++ b/meta-ar0521/conf/layer.conf
@@ -10,7 +10,7 @@ BBFILE_PATTERN_meta-econ = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-econ = "6"
 
 LAYERDEPENDS_meta-econ = "core"
-LAYERSERIES_COMPAT_meta-econ = "kirkstone"
+LAYERSERIES_COMPAT_meta-econ = "kirkstone scarthgap"
 
 TEZI_EXTERNAL_KERNEL_DEVICETREE_ADDED:apalis-imx8 = " apalis-imx8_ar0521_overlay.dtbo "
 TEZI_EXTERNAL_KERNEL_DEVICETREE_BOOT:append:apalis-imx8 = " apalis-imx8_ar0521_overlay.dtbo "


### PR DESCRIPTION
This builds and has basic functionality on the June 26th commit of the toradex-manifest repo's "scarthgap-7.x.y" branch on a Verdin imx8mm dev board. Because toradex-manifest's scarthgap branch is still on the 5.15 kernel, no adjustments to patches are needed yet.